### PR TITLE
Invalid en passant check when the game is initialized with a FEN-based constructor

### DIFF
--- a/ChessDotNetCore.Tests/FenConvertTests.cs
+++ b/ChessDotNetCore.Tests/FenConvertTests.cs
@@ -283,6 +283,48 @@ namespace ChessDotNetCore.Tests
             game.HalfMoveClock.Should().Be(0);
             game.FullMoveNumber.Should().Be(2);
         }
+        
+        [TestMethod]
+        public void TestChessGameFenConstructor_WhiteHasEnPassant()
+        {
+            const string fen = "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1";
+            var game = new ChessGame(fen);
+            game.EnPassant.Should().Be(new Position(Line.d, 6));
+        }
+        
+        [TestMethod]
+        public void TestChessGameFenConstructor_WhiteCanDoEnPassant()
+        {
+            const string fen = "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1";
+            var game = new ChessGame(fen);
+            var move = new Move(
+                new Position(Line.e, 5),
+                new Position(Line.d, 6),
+                Player.White);
+            var moveType = game.MakeMove(move, false);
+            moveType.Should().HaveFlag(MoveType.EnPassant);
+        }
+
+        [TestMethod]
+        public void TestChessGameFenConstructor_BlackHasEnPassant()
+        {
+            const string fen = "rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+            var game = new ChessGame(fen);
+            game.EnPassant.Should().Be(new Position(Line.e, 3));
+        }
+        
+        [TestMethod]
+        public void TestChessGameFenConstructor_BlackCanDoEnPassant()
+        {
+            const string fen = "rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+            var game = new ChessGame(fen);
+            var move = new Move(
+                new Position(Line.d, 4),
+                new Position(Line.e, 3),
+                Player.Black);
+            var moveType = game.MakeMove(move, false);
+            moveType.Should().HaveFlag(MoveType.EnPassant);
+        }
 
         [TestMethod]
         public void TestChessGameFenConstructorInvalid()

--- a/ChessDotNetCore/Pieces/Pawn.cs
+++ b/ChessDotNetCore/Pieces/Pawn.cs
@@ -150,6 +150,8 @@ namespace ChessDotNetCore.Pieces
             }
             if (checkEnPassant)
             {
+                if (game.EnPassant == destination)
+                    return true;
                 ReadOnlyCollection<DetailedMove> _moves = game.Moves;
                 if (_moves.Count == 0)
                 {


### PR DESCRIPTION
Added tests:

1. To verify the correctness of the EnPassant property when initializing via the FEN-based constructor.
2. To verify the ability to perform an en passant move.

Details can be found in the commits and their descriptions.